### PR TITLE
add local model cache support for vllm engine

### DIFF
--- a/mlflow_extensions/serving/engines/base.py
+++ b/mlflow_extensions/serving/engines/base.py
@@ -118,6 +118,7 @@ class Command:
 @dataclass(frozen=True, kw_only=True)
 class EngineConfig(abc.ABC):
     model: str
+    cache_dir: Optional[str] = field(default=None)
     host: str = field(default="0.0.0.0")
     port: int = field(default=9989)
     openai_api_path: int = field(default="v1")
@@ -148,7 +149,6 @@ class EngineConfig(abc.ABC):
         mlflow_extensions_version: str = None,
         **kwargs,
     ) -> List[str]:
-
         mlflow_extensions_version = (
             mlflow_extensions_version or get_mlflow_extensions_version()
         )
@@ -179,7 +179,6 @@ class EngineConfig(abc.ABC):
 
 
 class EngineProcess(abc.ABC):
-
     def __init__(self, *, config: EngineConfig):
         self._config = config
         self._lock = FileLock(f"{self.__class__.__name__}.txt.lock")

--- a/mlflow_extensions/serving/engines/huggingface_utils.py
+++ b/mlflow_extensions/serving/engines/huggingface_utils.py
@@ -1,8 +1,10 @@
 import json
+import shutil
+import os
 from pathlib import Path
 
 try:
-    from huggingface_hub import snapshot_download
+    from huggingface_hub import snapshot_download, scan_cache_dir
 except ImportError as e:
     print(
         "Error importing huggingface_hub module please run pip install huggingface_hub or upgrade the sdk "
@@ -19,6 +21,47 @@ def snapshot_download_local(repo_id: str, local_dir: str, tokenizer_only: bool =
         kwargs["ignore_patterns"] = ["*.bin", "*.safetensors"]
     snapshot_download(repo_id=repo_id, local_dir=model_local_path, **kwargs)
     return model_local_path
+
+
+def get_local_snapshot(repo_id, cache_dir, local_dir):
+    """
+    Scans local_dir for a model matching the repo_id and returns the path or None.
+    Also supports non-cache directories.
+    """
+    snapshot_path = None
+
+    try:
+        scan = scan_cache_dir(cache_dir=cache_dir)
+        for repo in [r for r in scan.repos if r.repo_id == repo_id]:
+            for rev in repo.revisions:
+                snapshot_path = rev.snapshot_path
+                break
+            if snapshot_path:
+                break
+
+    except Exception as e:
+        print(f"Cache directory scan failed: {e}")
+
+        # If scan_cache_dir doesn't work, check if the directory contains config.json
+        if os.path.exists(local_dir):
+            config_path = os.path.join(local_dir, "config.json")
+            if os.path.exists(config_path):
+                snapshot_path = local_dir
+
+        if not snapshot_path:
+            print("No valid model directory found.")
+
+    finally:
+        # If a snapshot was found and local_dir is specified, copy the contents
+        if snapshot_path:
+            try:
+                shutil.copytree(snapshot_path, local_dir, dirs_exist_ok=True)
+                print(f"Model copied to {local_dir}")
+                return local_dir
+            except Exception as e:
+                print(f"Failed to copy model to {local_dir}: {e}")
+
+    return snapshot_path
 
 
 def ensure_chat_template(tokenizer_file: str, chat_template_key: str = "chat_template"):

--- a/mlflow_extensions/serving/engines/vllm_engine.py
+++ b/mlflow_extensions/serving/engines/vllm_engine.py
@@ -14,6 +14,7 @@ from mlflow_extensions.serving.engines.base import (
 )
 from mlflow_extensions.serving.engines.huggingface_utils import (
     snapshot_download_local,
+    get_local_snapshot,
     ensure_chat_template,
 )
 
@@ -148,6 +149,11 @@ class VLLMEngineConfig(EngineConfig):
         return default_installs
 
     def _setup_snapshot(self, local_dir: str = "/root/models"):
+        if local_hf_model_path := get_local_snapshot(
+            self.model, self.cache_dir, local_dir
+        ):
+            return local_hf_model_path
+
         return snapshot_download_local(repo_id=self.model, local_dir=local_dir)
 
     def _setup_artifacts(self, local_dir: str = "/root/models"):
@@ -234,7 +240,6 @@ class VLLMEngineConfig(EngineConfig):
 
 
 class VLLMEngineProcess(EngineProcess):
-
     @property
     def engine_name(self) -> str:
         return "vllm-engine"


### PR DESCRIPTION
This change allows for using cached or pre-downloaded modes from various directory types.

Adds a huggingface util `get_local_snapshot` to support reading from hf cache or other pre-downloaded model directory

- First attempt scanning hf cache
- Fallback to check for `config.json` in non-cache directories
- Copy model to local_dir
